### PR TITLE
Add Google Analytics tracking code for MB tutorials.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_name: Bioinformatics Documentation
 
 repo_name: melbournebioinformatics/MelBioInf_docs
 repo_url: https://github.com/melbournebioinformatics/MelBioInf_docs
+google_analytics: ['UA-21794901-5', 'www.melbournebioinformatics.org.au/tutorials/']
 
 # needs pip install mkdocs-material
 theme: 'material'


### PR DESCRIPTION
We now have a separate tracking code for tutorials/workshops under our MB Google Analytics account. I've added this code to the mkdocs build.

This should track hits to any version of the tutorials built from this source, i.e. both the version hosted at https://www.melbournebioinformatics.org.au/tutorials/ and https://melbournebioinformatics.github.io/MelBioInf_docs (once deployments are updated). It will also of course capture hits whether they come in via the Melbourne Bioinformatics website, GVL website, or elsewhere.

One caveat is that hits to anyone's deployed fork of this repository will also be captured. This is probably a good thing - we sometimes run workshops from a fork if people are making last-minute edits. 

We'll also capture hits to test/dev deployments, but this should be low-volume.