### PR TITLE
Galaxy au

### DIFF
--- a/docs/tutorials/galaxy-workflows/galaxy-workflows.md
+++ b/docs/tutorials/galaxy-workflows/galaxy-workflows.md
@@ -32,7 +32,7 @@ This workshop/tutorial will familiarise you with the Galaxy workflow engine. It 
 
 ## Section 1: Preparation.
 
-The purpose of this section is to get you to log in to the server.. For this workshop, you can use a Galaxy server that you have created by following the steps outlined in: [Launch a GVL Galaxy Instance]() or you can use the public [Galaxy-mel](http://galaxy-mel.genome.edu.au)
+The purpose of this section is to get you to log in to the server.. For this workshop, you can use a Galaxy server that you have created by following the steps outlined in: [Launch a GVL Galaxy Instance]() or you can use the public [Galaxy Australia](https://usegalaxy.org.au/)
 
 
 **Go to Galaxy URL of your server in Firefox or Chrome (your choice, please don't use IE or Safari.)**

--- a/docs/tutorials/galaxy_101/galaxy_101.md
+++ b/docs/tutorials/galaxy_101/galaxy_101.md
@@ -72,7 +72,7 @@ The purpose of this section is to get you to log in to the server.
 
 1. Open your browser. We recommend Firefox or Chrome (please don't use Internet Explorer or Safari).
 
-    * Go to the [Galaxy-Mel](https://galaxy-mel.genome.edu.au/galaxy/) server.
+    * Go to the [Galaxy Australia](https://usegalaxy.org.au/) server.
     * Alternatively, you can use a different Galaxy server - a list of available servers is [here](https://galaxyproject.org/galaxy-services/).
 
 2. If you have previously registered on this server just log in:

--- a/docs/tutorials/gvl_launch/gvl_launch.md
+++ b/docs/tutorials/gvl_launch/gvl_launch.md
@@ -69,7 +69,7 @@ A private GVL server is a virtual machine running on the cloud and contains a
 pre-installed suite of tools for performing bioinformatics analyses. It differs
 from public GVL servers (such as the
 [Galaxy Tutorial Server](http://galaxy-tut.genome.edu.au/),
-[Galaxy Melbourne](http://galaxy-mel.genome.edu.au/), and
+[Galaxy Australia](https://usegalaxy.org.au/), and
 [Galaxy Queensland](http://galaxy-qld.genome.edu.au/)) by providing full
 administrative access to the server, as well as the full suite of GVL services,
 whereas public GVL servers provide restricted access for security reasons.

--- a/docs/tutorials/rna_seq_dge_advanced/rna_seq_advanced_tutorial.md
+++ b/docs/tutorials/rna_seq_dge_advanced/rna_seq_advanced_tutorial.md
@@ -82,7 +82,7 @@ tutorial a suitable length. This has implications, as discussed in section 8.
 1.  Open a browser and go to a Galaxy server. This can either be your
     personal GVL server you [started previously](http://genome.edu.au/get/get#launch),
     the public [Galaxy Tutorial server](http://galaxy-tut.genome.edu.au)
-    or the public [Galaxy Melbourne server](http://galaxy-mel.genome.edu.au).  
+    or the public [Galaxy Australia](https://usegalaxy.org.au/).  
     Recommended browsers include Firefox and Chrome. Internet Explorer
     is not supported.
 2.  Register as a new user by clicking **User > Register** on the top

--- a/docs/tutorials/rna_seq_dge_basic/rna_seq_basic_tutorial.md
+++ b/docs/tutorials/rna_seq_dge_basic/rna_seq_basic_tutorial.md
@@ -120,7 +120,7 @@ be to find differentially expressed genes in WT vs KO.
 1.  Open a browser and go to a Galaxy server. This can either be your
     personal GVL server you [started previously](http://genome.edu.au/get/get#launch),
     the public [Galaxy Tutorial server](http://galaxy-tut.genome.edu.au)
-    or the public [Galaxy Melbourne server](http://galaxy-mel.genome.edu.au).  
+    or the public [Galaxy Australia](https://usegalaxy.org.au/).  
     Recommended browsers include Firefox and Chrome. Internet Explorer
     is not supported.
 2.  Register as a new user by clicking **User > Register** on the top

--- a/docs/tutorials/rna_seq_dge_basic/rna_seq_basic_tuxedo.md
+++ b/docs/tutorials/rna_seq_dge_basic/rna_seq_basic_tuxedo.md
@@ -127,7 +127,7 @@ More information about the Tuxedo protocol can be found [here](rna_seq_basic_bac
 1.  Open a browser and go to a Galaxy server. This can either be your
     personal GVL server you [started previously](http://genome.edu.au/get/get#launch),
     the public [Galaxy Tutorial server](http://galaxy-tut.genome.edu.au)
-    or the public [Galaxy Melbourne server](http://galaxy-mel.genome.edu.au).  
+    or the public [Galaxy Australia](https://usegalaxy.org.au/).  
     Recommended browsers include Firefox and Chrome. Internet Explorer
     is not supported.
 2.  Register as a new user by clicking **User > Register** on the top

--- a/docs/tutorials/var_detect_advanced/var_detect_advanced.md
+++ b/docs/tutorials/var_detect_advanced/var_detect_advanced.md
@@ -29,7 +29,7 @@ The data has been produced from human whole genomic DNA. Only reads that have ma
 ## Preparation
 
 1. **Make sure you have an instance of Galaxy ready to go.**
-    * If you don't have your own - go to our [Galaxy-Tut](http://galaxy-tut.genome.edu.au/galaxy) or [Galaxy-Melbourne](http://galaxy-mel.genome.edu.au/galaxy) server.
+    * If you don't have your own - go to our [Galaxy-Tut](http://galaxy-tut.genome.edu.au/galaxy) or [Galaxy Australia](https://usegalaxy.org.au/) server.
     * Log in so that your work will be saved.
     If you don't already have an account on this server, select from the menu *User -> Register* and create one.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,6 @@ pages:
   - 'Galaxy Workflows':
     - 'Tutorial': 'tutorials/galaxy-workflows/galaxy-workflows.md'
     - 'History Creation': 'tutorials/galaxy-workflows/history_creation.md'
-  - 'Introduction to GenomeSpace' : 'tutorials/genomespace/genomespace.md'
   - 'Containerized Bioinformatics': 'tutorials/docker/docker.md'
 - 'Genomics Tutorials':
   - 'Introduction to Variant Calling': 'tutorials/variant_calling_galaxy_1/variant_calling_galaxy_1.md'


### PR DESCRIPTION
Replace Galaxy-Mel references with Galaxy Australia, since Galaxy-Mel is being turned off.

Retire GenomeSpace tutorial (unlinked but not deleted).