### PR TITLE
Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: trusty
+language: python
+python:
+- '3.6'
+install:
+- pip install -r requirements.txt
+script:
+- git config user.name "Travis CI"
+- git config user.email "travis@travis-ci.org";
+- git remote add authenticated "https://${GH_TOKEN}@github.com/melbournebioinformatics/MelBioInf_docs_test";
+- git fetch authenticated && git fetch authenticated gh-pages:gh-pages;
+- mkdocs gh-deploy --clean --remote-name authenticated;
+env:
+  global:
+    secure: PiISdb3a7OwKBV9wWqWTZVYPgPkU8/mmdEmmn/x5EPEH6kiIdX8cu10tyTcsADi4vgzXPdojAo2wg2bTllYd7jzaxux/gvbSQwCPBjMEAtZ68318/G+JMXAOMhisKjveaQNg0XwnxYCRQZdHCd/85ohWYIwD3V68I9uTbT/W4o+/62aF5u4v8kt1qgQWsz6Kt/T1rrx9xArc4h3aLQazzOICNt2DdPIipmosHqVzKk4m+LWvPhU0+DDHC0LexPRICgIZehgvUXdghpwPI5ULki5KmzXxos2WKvuu+NZZ0Dixdnt7aYhmCLpEZdKVnFsj+E9ia+/bBdudqX3S+6wlowr6lAC4pSkj2JQw+pQiSQfAv2Q0A9XkI9Po2HBKdYXA3eWX9ract28mYXHTRwgnFnuMVtTnOw8P2Wifm4R1TjVpkgyRAs6OQOIxNqgOIsObauoFgcjxpY3LlPqdzqQE+OgAfP7OsGi2Tn0Sekj3WEv8zjDvLFBA1aQFJNThm9/x6xkRQrG0x2T+h/4QzUWNJRvcN2WkL6sYx5SCIqVNS6lhPO7y6EH5fb6/FYVqtVoQGT0eXfr7AG9GThJjMDrTEfIsZ6Av0ln4KJf2GZzPjkWQ19p+CltPaxOCrVvtoZYmRasgy1OuT7vWeAe2EVGOBIiaiIuZOdSZI7l1/wqtoP8=

--- a/README.md
+++ b/README.md
@@ -123,23 +123,22 @@ Preferably, change one major thing per pull request - e.g. edit one tutorial in 
 
 ## Merging and deploying a pull request
 
-If someone has asked you to merge their PR, or if you are merging in your own:
+If someone has asked you to merge their PR, or if you are merging in your own, you can simply merge it and the documentation will be re-deployed. Best practice is:
 
 * Check the changes in github to spot any errors. You should be able to see the diff for the changes if the requester has sent you a link to their Pull Request.
 * Optionally, to view the new docs in their final form:
-	- view the deployed site at the requester's fork. This will be at `http://<requesters_account>.github.io/MelBioInf_docs/` *if* the author has run `mkdocs gh-deploy` on their fork. Or,
-	- clone and build the requester's fork locally, using the [instructions above](#set-up-your-environment-and-build-the-documentation).
+	- view the deployed site at the requester's fork. This will be at `http://<requesters_account>.github.io/MelBioInf_docs/` *if* the author has run `mkdocs gh-deploy` on their fork.
+	- or, clone and build the requester's fork locally, using the [instructions above](#set-up-your-environment-and-build-the-documentation).
 * Merge the PR in github. If there are merge conflicts, ask the issuer of the pull request to bring their fork up to date (see [Sync with upstream](#sync-with-upstream)) and re-issue the pull request.
-* Clone or update a local copy of this repository, and re-deploy the updated documentation, like so:
 
+It should no longer be necessary to manually re-deploy the documentation to the gh-pages branch. We have a Travis hook configured in `.travis.yml` which will automatically run `mkdocs gh-deploy` whenever the master branch changes. After merging a PR or modifying the master branch, after a short delay, the updated tutorial should automatically appear at http://melbournebioinformatics.github.io/MelBioInf_docs/ .
+
+If you do need to manually re-deploy the documentation to the gh-pages branch, you can clone or update a local copy of this repository, and re-deploy the updated documentation, like so:
 ```
 git clone https://github.com/melbournebioinformatics/MelBioInf_docs
 cd MelBioInf_docs
 mkdocs gh-deploy
 ```
-Note: this is a direct copy of the repository, not a clone of your copy of the repository. 
-
-Check that the updated tutorial appears under http://melbournebioinformatics.github.io/MelBioInf_docs/
 
 ## Making changes to tutorial instructions
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 	- [Making changes to tutorial instructions](#making-changes-to-tutorial-instructions)
 	- [Making changes to slides](#making-changes-to-slides)
 	- [Adding a new tutorial](#adding-a-new-tutorial)
+- [Travis configuration](#travis-configuration)
 
 <!-- /TOC -->
 
@@ -181,3 +182,16 @@ Once you've created your content:
 * Before committing changes, add all newly created files to git with `git add`.
 * Follow the [How to contribute](#how-to-contribute) instructions above to create a pull request. When previewing your changes, check that the new tutorial appears in the menu and renders correctly.
 * Tell Christina that there is a new workshop available.
+
+# Travis configuration
+
+A Travis hook to automatically re-deploy documentation from the master branch to the gh-pages branch is configured in `.travis.yml`. This uses a GitHub personal access token for permission to re-deploy. If you need to alter the Travis setup, you may find you need to generate a new personal access token using the account of a https://github.com/melbournebioinformatics member with write permission to this repository. This can be done by:
+
+* Generating a new GitHub personal access token at https://github.com/settings/tokens
+* If necessary, installing Ruby on the machine you will be using (this is operating-system dependent)
+* Installing the Travis-CI command line tools - on Linux and Mac, this is `sudo gem install travis`
+* Cloning this repository in order update `.travis.yml`
+* Running `travis encrypt GH_TOKEN=<your_token_here> -r melbournebioinformatics/MelBioInf_docs --add`. This will add your encrypted access token to `.travis.yml`.
+* Committing the updated `.travis.yml` and pushing up to this repository.
+
+This will allow you to use [Travis](http://travis-ci.org) to manage the build, using the GitHub account used to generate the new access token.


### PR DESCRIPTION
This PR adds a Travis config to automatically run `mkdocs gh-deploy` whenever the master branch of the repo is updated. It means approved pull requests will now update https://github.com/melbournebioinformatics/MelBioInf_docs automatically without any manual re-deployment step. Re-deployments should appear as commits on the gh-pages branch, authored by "Travis CI" (this username is configured in `.travis.yml`). I've updated the README to reflect the simplified deployment process.

Under our current configuration, this will also update the training portion of the website. 

This is currently using a GitHub personal access token from my GitHub account; I think a personal access token is the only way we can currently do this. I think, but am not sure, that anyone else with permission could configure and run the Travis build while still leaving my token in place for the deployment permission (so long as my account still has write access, of course). However I've also added a note to the README on how the deployment permission was set up, in case this does need to be redone.
